### PR TITLE
VNTextProxy: Add d3d9.dll proxy for BGI/Ethornell support

### DIFF
--- a/VNTextProxy/D3D9Proxy/Proxy.cpp
+++ b/VNTextProxy/D3D9Proxy/Proxy.cpp
@@ -1,0 +1,20 @@
+#include "pch.h"
+
+void Proxy::Init()
+{
+    wchar_t realDllPath[MAX_PATH];
+    GetSystemDirectory(realDllPath, MAX_PATH);
+    wcscat_s(realDllPath, L"\\d3d9.dll");
+    HMODULE hDll = LoadLibrary(realDllPath);
+    if (hDll == nullptr)
+    {
+        MessageBox(nullptr, L"Cannot load original d3d9.dll library", L"Proxy", MB_ICONERROR);
+        ExitProcess(0);
+    }
+
+#define RESOLVE(fn) Original##fn = reinterpret_cast<decltype(Original##fn)>(GetProcAddress(hDll, #fn))
+    RESOLVE(Direct3DCreate9);
+#undef RESOLVE
+}
+
+__declspec(naked) void FakeDirect3DCreate9() { _asm { jmp[Proxy::OriginalDirect3DCreate9] } }

--- a/VNTextProxy/D3D9Proxy/Proxy.h
+++ b/VNTextProxy/D3D9Proxy/Proxy.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class Proxy
+{
+public:
+    static void Init();
+
+    static inline void *OriginalDirect3DCreate9{};
+};

--- a/VNTextProxy/D3D9Proxy/exports.def
+++ b/VNTextProxy/D3D9Proxy/exports.def
@@ -1,0 +1,3 @@
+LIBRARY d3d9
+EXPORTS
+    Direct3DCreate9=FakeDirect3DCreate9 @9


### PR DESCRIPTION
Howdy! @pdvt and I are working on a BGI/Ethornell project, and were successful in having VNTextProxy run with GdiProportionalizer by proxy'ing BGI's `d3d9.dll`. Figured we'd share the proxy code for future BGI/Ethornell hackers. Tried to follow the structure of other proxy folders.