### PR TITLE
Updated Kirikiri.cs

### DIFF
--- a/VNTextPatch.Shared/Scripts/Kirikiri/KirikiriScript.cs
+++ b/VNTextPatch.Shared/Scripts/Kirikiri/KirikiriScript.cs
@@ -14,11 +14,11 @@ namespace VNTextPatch.Shared.Scripts.Kirikiri
 
         private static readonly Regex PlainRubyRegex = new Regex(@"\[(?<text>[^/\]]+?)/(?<ruby>[^\]]+?)\]", RegexOptions.Compiled);
 
-        private static readonly string[] NameCommands = { "nm", "set_title", "speaker", "Talk" };
+        private static readonly string[] NameCommands = { "nm", "set_title", "speaker", "Talk", "cn" , "name"};
         private static readonly string[] EnterNameCommands = { "ns" };
         private static readonly string[] ExitNameCommands = { "nse" };
         private static readonly string[] MessageCommands = { "sel01", "sel02", "sel03", "sel04", "AddSelect", "ruby" };
-        private static readonly string[] AllowedInlineCommands = { "r", "ruby", "ruby_c", "heart", "・" };
+        private static readonly string[] AllowedInlineCommands = { "r", "ruby", "ruby_c", "heart", "・", "mruby"};
 
         private ScriptStringType _currentStringType;
 


### PR DESCRIPTION
-Added "mruby" command to AllowedInlineCommands. Normally used for furigana readings. Should be replaced when translating.
-Added "cn" and "name" to NameCommands to identify more character names in some Kirikiri games.